### PR TITLE
Events datamodel and new additions

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,10 +1,10 @@
 class Event < ActiveRecord::Base
   belongs_to :user
-  has_many :tags
+	has_many :eventTags
+	has_many :tags, through: :eventTags
 
-
-  validates :title, :presence => true
-  validates :description, :presence => true
-  validates :date, :presence => true
-  validates :time, :presence => true
+  # validates :title, :presence => true
+  # validates :description, :presence => true
+  # validates :date, :presence => true
+  # validates :time, :presence => true
 end

--- a/app/models/event_tag.rb
+++ b/app/models/event_tag.rb
@@ -1,0 +1,4 @@
+class EventTag < ActiveRecord::Base
+	belongs_to :tag
+	belongs_to :event
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,4 @@
 class Tag < ActiveRecord::Base
-  belongs_to :event
+	has_many :eventTags
+	has_many :events, through: :eventTags
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable,
 				 :omniauthable, :omniauth_providers => [:facebook]
 
-	has_many :events
+	has_many :events, foreign_key: "user_id", class_name: "UserEvents"
 
 	def self.from_omniauth(auth)
 	  where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable,
 				 :omniauthable, :omniauth_providers => [:facebook]
 
-	has_many :events, foreign_key: "user_id", class_name: "UserEvents"
+	has_many :events_owned, foreign_key: "user_id", class_name: "Event"
+	has_many :events_attending, foreign_key: "user_id", class_name: "UserEvent"
 
 	def self.from_omniauth(auth)
 	  where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/models/user_event.rb
+++ b/app/models/user_event.rb
@@ -1,0 +1,4 @@
+class UserEvent < ActiveRecord::Base
+	belongs_to :user
+	belongs_to :event
+end

--- a/db/migrate/20161112162719_create_events.rb
+++ b/db/migrate/20161112162719_create_events.rb
@@ -1,16 +1,27 @@
 class CreateEvents < ActiveRecord::Migration
   def change
     create_table :events do |t|
-      t.string     :title
-      t.string     :location
-      t.string     :address
-      t.string     :description
-      t.string     :city
-      t.datetime   :datetime
-      t.string     :facebook_url
-      t.string     :other_url
-      t.boolean    :approved?, :default => false
       t.references :user, index: true, foreign_key: true
+      t.string     :title
+      t.text       :description
+      t.datetime   :datetime
+
+      # Location information
+      t.string     :address1, default: ""
+      t.string     :address2, default: ""
+      t.string     :city, null: false
+      t.string     :state, null: false
+      t.integer    :zip, null: false
+
+      # Dropdown-selectable location category (i.e. New York, DC, San Francisco, Portland, etc)
+      t.string     :location
+      
+      # Link to event off-site from Protest45 for more info/original source
+      t.string     :url
+      t.string     :event_source # i.e. dropdown selectable Facebook, Meetup, Craigslist, Other
+
+      # for Admin users
+      t.boolean    :approved?, :default => false
 
       t.timestamps null: false
     end

--- a/db/migrate/20161112162744_create_tags.rb
+++ b/db/migrate/20161112162744_create_tags.rb
@@ -2,7 +2,6 @@ class CreateTags < ActiveRecord::Migration
   def change
     create_table :tags do |t|
       t.string :name
-      t.references :event, index: true, foreign_key: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20161114165309_create_event_tags.rb
+++ b/db/migrate/20161114165309_create_event_tags.rb
@@ -1,0 +1,10 @@
+class CreateEventTags < ActiveRecord::Migration
+  def change
+    create_table :event_tags do |t|
+			t.references :event, index: true, foreign_key: true
+			t.references :tag, index: true, foreign_key: true
+			
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20161114165430_create_user_events.rb
+++ b/db/migrate/20161114165430_create_user_events.rb
@@ -1,0 +1,10 @@
+class CreateUserEvents < ActiveRecord::Migration
+  def change
+    create_table :user_events do |t|
+			t.references :user, index: true, foreign_key: true
+			t.references :event, index: true, foreign_key: true
+			
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,22 +11,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161112211507) do
+ActiveRecord::Schema.define(version: 20161114165430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "event_tags", force: :cascade do |t|
+    t.integer  "event_id"
+    t.integer  "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "event_tags", ["event_id"], name: "index_event_tags_on_event_id", using: :btree
+  add_index "event_tags", ["tag_id"], name: "index_event_tags_on_tag_id", using: :btree
+
   create_table "events", force: :cascade do |t|
-    t.string   "title"
-    t.string   "location"
-    t.string   "description"
-    t.string   "city"
-    t.date     "date"
-    t.time     "time"
-    t.string   "facebook_url"
-    t.string   "other_url"
-    t.boolean  "approved?",    default: false
     t.integer  "user_id"
+    t.string   "title"
+    t.text     "description"
+    t.datetime "datetime"
+    t.string   "address1",     default: ""
+    t.string   "address2",     default: ""
+    t.string   "city",                         null: false
+    t.string   "state",                        null: false
+    t.integer  "zip",                          null: false
+    t.string   "location"
+    t.string   "url"
+    t.string   "event_source"
+    t.boolean  "approved?",    default: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
   end
@@ -35,12 +48,19 @@ ActiveRecord::Schema.define(version: 20161112211507) do
 
   create_table "tags", force: :cascade do |t|
     t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "user_events", force: :cascade do |t|
+    t.integer  "user_id"
     t.integer  "event_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "tags", ["event_id"], name: "index_tags_on_event_id", using: :btree
+  add_index "user_events", ["event_id"], name: "index_user_events_on_event_id", using: :btree
+  add_index "user_events", ["user_id"], name: "index_user_events_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "",    null: false
@@ -66,6 +86,9 @@ ActiveRecord::Schema.define(version: 20161112211507) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "event_tags", "events"
+  add_foreign_key "event_tags", "tags"
   add_foreign_key "events", "users"
-  add_foreign_key "tags", "events"
+  add_foreign_key "user_events", "events"
+  add_foreign_key "user_events", "users"
 end


### PR DESCRIPTION
This pull drastically changes data model for the app to round out the capabilities.

First, Events now have the following:

- Creator reference
- Title
- Descrption **UPDATED to .text instead of string**
- DateTime
- Address (as Address line 1, line 2, city, state, zip for mapping purposes)
- Location (effectively a category for curated regional lists, i.e. NY, DC, SF, etc)
- a single URL field
- an additional field to add a source website (i.e. FB, Meetup, etc), can be used to trigger/display additional view features like an "I'm attending" button if it's a Facebook event
- Approval


Next up, I've added join tables for EventTags, and UserEvents, and the appropriate associations, and I've simplified the models they reference (Tags in particular). Tags only have a name now, and EventTags will allow us to display all events with a particular tag. UserEvents allows us to collect and display all events a user is attending/has attended, and I've added an alias association to the User model for events that they own, so we can display that user's events on their profile.

Pull me! :-)