### PR TITLE
Events controller cleanup and security

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,14 +1,13 @@
 class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
 
   # GET /events
-  # GET /events.json
   def index
     @events = Event.all
   end
 
   # GET /events/1
-  # GET /events/1.json
   def show
   end
 
@@ -22,43 +21,32 @@ class EventsController < ApplicationController
   end
 
   # POST /events
-  # POST /events.json
   def create
     @event = Event.new(event_params)
+    @event.user = current_user
 
-    respond_to do |format|
-      if @event.save
-        format.html { redirect_to @event, notice: 'Event was successfully created.' }
-        format.json { render :show, status: :created, location: @event }
-      else
-        format.html { render :new }
-        format.json { render json: @event.errors, status: :unprocessable_entity }
-      end
+    if @event.save
+      redirect_to @event, notice: 'Event was successfully created.'
+    else
+      render :new
     end
   end
 
   # PATCH/PUT /events/1
-  # PATCH/PUT /events/1.json
   def update
-    respond_to do |format|
-      if @event.update(event_params)
-        format.html { redirect_to @event, notice: 'Event was successfully updated.' }
-        format.json { render :show, status: :ok, location: @event }
-      else
-        format.html { render :edit }
-        format.json { render json: @event.errors, status: :unprocessable_entity }
-      end
+    if @event.update(event_params)
+      redirect_to @event, notice: 'Event was successfully updated.'
+    else
+      render :edit
     end
   end
 
   # DELETE /events/1
-  # DELETE /events/1.json
   def destroy
+    @event_tags = EventTag.where(event_id: @event.id)
+    @event_tags.each { |event_tag| event_tag.destroy }
     @event.destroy
-    respond_to do |format|
-      format.html { redirect_to events_url, notice: 'Event was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to events_url, notice: "Your event, '#{@event.title}' was successfully deleted."
   end
 
   private
@@ -69,6 +57,20 @@ class EventsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def event_params
-      params.require(:event).permit(:title, :location, :description, :date, :time, :facebook_url, :other_url, :approved?, :user_id)
+      params.require(:event).permit(
+        :user_id,
+        :title,
+        :description,
+        :datetime,
+        :address1,
+        :address2,
+        :city,
+        :state,
+        :zip,
+        :location,
+        :url,
+        :event_source,
+        :approved?)
     end
+
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,8 +3,13 @@ class Event < ActiveRecord::Base
 	has_many :eventTags
 	has_many :tags, through: :eventTags
 
-  # validates :title, :presence => true
-  # validates :description, :presence => true
-  # validates :date, :presence => true
-  # validates :time, :presence => true
+  validates :user_id, :title, :description, :datetime, :city, :state, :zip, :location,
+  	:presence => true
+  validates :zip, length: { is: 5 }, numericality: { only_integer: true }
+
+  def created_by?(user)
+  	return true if self.user == user
+  	return false
+  end
+
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -40,7 +40,11 @@
         <%= f.label :location %>
       </div>
       <div class="col-sm-9">        
-        <%= f.text_field :location %>
+        <%= select_tag( 'event[location]',
+              options_for_select([['Select a Location',nil],
+                                  ['Washington, DC','Washington, DC'],
+                                  ['New York, NY','New York, NY'],
+                                  ['San Francisco, CA','San Francisco, CA'] ])) %>
       </div>
     </div>
 
@@ -69,7 +73,10 @@
         <%= f.label :event_source %>
       </div>
       <div class="col-sm-9">
-        <%= f.text_field :event_source %>
+        <%= select_tag( 'event[event_source]',
+              options_for_select([['Facebook','Facebook'],
+                                  ['Meetup.com','Meetup.com'],
+                                  ['Other','Other'] ])) %>
       </div>
     </div>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,8 @@
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+
+
 <%= form_for(@event) do |f| %>
+  <!-- For Error handling -->
   <% if @event.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@event.errors.count, "error") %> prohibited this event from being saved:</h2>
@@ -11,43 +15,113 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :title %><br>
-    <%= f.text_field :title %>
-  </div>
-  <div class="field">
-    <%= f.label :location %><br>
-    <%= f.text_field :location %>
-  </div>
-  <div class="field">
-    <%= f.label :description %><br>
-    <%= f.text_field :description %>
-  </div>
-  <div class="field">
-    <%= f.label :date %><br>
-    <%= f.date_select :date %>
-  </div>
-  <div class="field">
-    <%= f.label :time %><br>
-    <%= f.time_select :time %>
-  </div>
-  <div class="field">
-    <%= f.label :facebook_url %><br>
-    <%= f.text_field :facebook_url %>
-  </div>
-  <div class="field">
-    <%= f.label :other_url %><br>
-    <%= f.text_field :other_url %>
-  </div>
-  <div class="field">
-    <%= f.label :approved? %><br>
-    <%= f.check_box :approved? %>
-  </div>
-  <div class="field">
-    <%= f.label :user_id %><br>
-    <%= f.text_field :user_id %>
-  </div>
+  <!-- Mandatory info -->
+<div class="container">
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label  :title %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :title %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :description %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_area :description %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :location %>
+      </div>
+      <div class="col-sm-9">        
+        <%= f.text_field :location %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-12">
+        <%= f.label "Date and Time" %>
+      </div>
+      <div class="col-sm-12">
+        <%= f.datetime_select(:datetime, ampm: true ) %>
+      </div>
+    </div>
+
+  <!-- URL -->
+    <br><br>
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label "URL" %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :url %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :event_source %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :event_source %>
+      </div>
+    </div>
+
+  <!-- Address for Maps-->
+    <br><br>
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :address1 %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :address1 %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :address2 %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :address2 %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :city %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :city %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :state %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :state %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-3">
+        <%= f.label :zip %>
+      </div>
+      <div class="col-sm-9">
+        <%= f.text_field :zip %>
+      </div>
+    </div>
+
   <div class="actions">
     <%= f.submit %>
   </div>
+</div>
 <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -2,5 +2,11 @@
 
 <%= render 'form' %>
 
-<%= link_to 'Show', @event %> |
-<%= link_to 'Back', events_path %>
+<br><br>
+
+<small>Warning: This action cannot be undone!</small><br>
+<%= button_to "Delete #{@event.title}?", event_path, method: "delete" %>
+
+<br><br>
+<%= link_to "Back to #{@event.title}", @event %> |
+<%= link_to 'Back to Events', events_path %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,14 +7,12 @@
 
        <div class="">
           <h3><%= link_to event.title, event %></h3>
-          <p><%= event.date %> - <%= event.time %></p>
+          <p><%= event.datetime %></p>
           <p><%= event.location %></p>
           <p><%= event.description %></p>
 
-          <% if event.facebook_url %>
-            <%= link_to 'Go', event.facebook_url %>
-          <% else %>
-            <%= link_to 'Go', event.other_url %>
+          <% if event.url %>
+            <%= link_to 'Go', event.url %>
           <% end %>
       </div>
     <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,22 +17,12 @@
 
 <p>
   <strong>Date:</strong>
-  <%= @event.date %>
+  <%= @event.datetime %>
 </p>
 
 <p>
-  <strong>Time:</strong>
-  <%= @event.time %>
-</p>
-
-<p>
-  <strong>Facebook url:</strong>
-  <%= @event.facebook_url %>
-</p>
-
-<p>
-  <strong>Other url:</strong>
-  <%= @event.other_url %>
+  <strong>Link:</strong>
+  <%= @event.url %>
 </p>
 
 <p>
@@ -41,8 +31,8 @@
 </p>
 
 <p>
-  <strong>User:</strong>
-  <%= @event.user %>
+  <strong>Event Creator:</strong>
+  <%= @event.user.name %>
 </p>
 
 <%= link_to 'Edit', edit_event_path(@event) %> |

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -35,5 +35,7 @@
   <%= @event.user.name %>
 </p>
 
+<% if @event.created_by?(current_user) %>
 <%= link_to 'Edit', edit_event_path(@event) %> |
+<% end %>
 <%= link_to 'Back', events_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,9 @@
 <body>
 <nav>
 	<ul>
+		<li><a href="/">Home</a></li>
 	<% if user_session %>
+		<li><a href="/events/new">Post a New Event</a></li>
 		<li><a href="/users/sign_out">Sign Out</a></li>
 	<% else %>
 		<li><a href="/users/sign_up">Register</a></li>
@@ -17,9 +19,6 @@
 	<% end %>
 	</ul>
 </nav>
-
-<p class="notice"><%= notice %></p>
-<p class="alert"><%= alert %></p>
 
 <%= yield %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
 
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   resources :events
-  resources :users
 
   get '/'=> 'events#index'
   get    'login'   => 'sessions#new'

--- a/db/migrate/20161112162719_create_events.rb
+++ b/db/migrate/20161112162719_create_events.rb
@@ -2,9 +2,9 @@ class CreateEvents < ActiveRecord::Migration
   def change
     create_table :events do |t|
       t.references :user, index: true, foreign_key: true
-      t.string     :title
-      t.text       :description
-      t.datetime   :datetime
+      t.string     :title, null: false
+      t.text       :description, null: false
+      t.datetime   :datetime, null: false
 
       # Location information
       t.string     :address1, default: ""
@@ -14,7 +14,7 @@ class CreateEvents < ActiveRecord::Migration
       t.integer    :zip, null: false
 
       # Dropdown-selectable location category (i.e. New York, DC, San Francisco, Portland, etc)
-      t.string     :location
+      t.string     :location, null: false
       
       # Link to event off-site from Protest45 for more info/original source
       t.string     :url


### PR DESCRIPTION
Security implemented for Events CRUD functionality. Only registered users can CRUD, only owners of an event or an admin can edit or delete.
Dropdown menu for Location added to the events new/edit form. Populated it with NYC, SF, and DC for now - will let someone else make the call on what cities or regions we want there.
General tidying up throughout, and a model method added to the Event model to give logic to the view layer ( `@event.created_by?(current_user)` returns true or false for conditional links to edit/delete!)