### PR TITLE
Change eventTags refs to event_tags, display current_user's email

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ActiveRecord::Base
   belongs_to :user
-	has_many :eventTags
-	has_many :tags, through: :eventTags
+	has_many :event_tags
+	has_many :tags, through: :event_tags
 
   validates :user_id, :title, :description, :datetime, :city, :state, :zip, :location,
   	:presence => true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
 class Tag < ActiveRecord::Base
-	has_many :eventTags
-	has_many :events, through: :eventTags
+	has_many :event_tags
+	has_many :events, through: :event_tags
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 
 <footer>
 	<% if current_user %>	
-		<p>You are logged in as <%= current_user.name %></p>
+		<p>You are logged in as <%= current_user.email %></p>
 	<% end %>
 </footer>
 </body>


### PR DESCRIPTION
Events and Tags models referenced the EventTags table as eventTags-this might have caused an error, so I changed the references to event_tags, following usual Rails convention.

Also have the current_user's email on that events index page.